### PR TITLE
Fix delete qualification 'Device::'

### DIFF
--- a/device.h
+++ b/device.h
@@ -32,7 +32,7 @@ public:
     // Always constructed in an undefined state.
     // Client must create an array of device objects
     // before configuring each one individually.
-    Device::Device();    
+    Device();    
 
     // Destructor
     // Deletes extant buffers


### PR DESCRIPTION
```
In file included from CLKernel.cpp:10:
device.h:35:5: error: extra qualification 'Device::' on member 'Device' [-fpermissive]
   35 |     Device::Device();
      |     ^~~~~~
```