### PR TITLE
Fix added <cstddef>

### DIFF
--- a/MultiFrameRequest.cpp
+++ b/MultiFrameRequest.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "MultiFrameRequest.h"
+#include <cstddef>
 
 void MultiFrameRequest::Request(int frame_number) {
     frames_.insert(pair<int, const unsigned char*>(frame_number, static_cast<const unsigned char*>(NULL)));


### PR DESCRIPTION
```
MultiFrameRequest.cpp: In member function 'void MultiFrameRequest::Request(int)':
MultiFrameRequest.cpp:12:100: error: 'NULL' was not declared in this scope
   12 |     frames_.insert(pair<int, const unsigned char*>(frame_number, static_cast<const unsigned char*>(NULL)));
      |                                                                                                    ^~~~
MultiFrameRequest.cpp:9:1: note: 'NULL' is defined in header '<cstddef>'; did you forget to '#include <cstddef>'?
    8 | #include "MultiFrameRequest.h"
  +++ |+#include <cstddef>
```